### PR TITLE
Personal Recommendations call parameter update

### DIFF
--- a/src/Entity/Book.php
+++ b/src/Entity/Book.php
@@ -206,7 +206,7 @@ abstract class Book extends Entity
         int $limit = 5,
         array $bookTypes = ['pdf']
     ) : BookboonResponse {
-        $bResponse = $bookboon->rawRequest('/recommendations', ['limit' => $limit, 'book' => $bookIds, 'bookType' => join(',', $bookTypes)]);
+        $bResponse = $bookboon->rawRequest('/recommendations', ['limit' => $limit, 'books' => $bookIds, 'bookType' => join(',', $bookTypes)]);
 
         $bResponse->setEntityStore(
             new EntityStore(Book::getEntitiesFromArray($bResponse->getReturnArray()))


### PR DESCRIPTION
API expects for `books` parameter `book` is passed. Without `books` parameter general recommendations are returned