### PR TITLE
Update/entity update for old platform

### DIFF
--- a/src/Cache/HashTrait.php
+++ b/src/Cache/HashTrait.php
@@ -21,7 +21,7 @@ trait HashTrait
         $headerString = "";
         foreach ($headers as $key => $value) {
             if ($key != Headers::HEADER_XFF) {
-                $headerString = $key.$value;
+                $headerString .= $key.$value;
             }
         }
 
@@ -39,11 +39,7 @@ trait HashTrait
      */
     public function isCachable($url, $httpMethod)
     {
-        if ($httpMethod === Client::HTTP_GET && $this->isInitialized()) {
-            return true;
-        }
-
-        return false;
+        return $httpMethod === Client::HTTP_GET && $this->isInitialized();
     }
 
     /**

--- a/src/Cache/MemcachedCache.php
+++ b/src/Cache/MemcachedCache.php
@@ -88,6 +88,6 @@ class MemcachedCache implements Cache
      */
     public function isInitialized()
     {
-        return $this->cache == null;
+        return $this->cache != null;
     }
 }

--- a/src/Client/Oauth/BookboonProvider.php
+++ b/src/Client/Oauth/BookboonProvider.php
@@ -17,8 +17,11 @@ class BookboonProvider extends AbstractProvider
 {
     use BearerAuthorizationTrait;
 
-    const AUTHORIZE = '/authorize';
-    const ACCESS_TOKEN = '/access_token';
+
+    const AUTHORIZE = '/login/authorize';
+    const ACCESS_TOKEN = '/login/access_token';
+    const PROTOCOL = 'https';
+    const HOST = 'bookboon.com';
 
     /**
      * @var string
@@ -80,7 +83,7 @@ class BookboonProvider extends AbstractProvider
      */
     public function getBaseAuthorizationUrl()
     {
-        return Client::API_PROTOCOL . '://' . Client::API_URL . self::AUTHORIZE;
+        return self::PROTOCOL . '://' . self::HOST . self::AUTHORIZE;
     }
 
     /**
@@ -93,7 +96,7 @@ class BookboonProvider extends AbstractProvider
      */
     public function getBaseAccessTokenUrl(array $params)
     {
-        return Client::API_PROTOCOL . '://' . Client::API_URL . self::ACCESS_TOKEN;
+        return self::PROTOCOL . '://' . self::HOST . self::ACCESS_TOKEN;
     }
 
     /**
@@ -104,7 +107,7 @@ class BookboonProvider extends AbstractProvider
      */
     public function getResourceOwnerDetailsUrl(AccessToken $token)
     {
-        return Client::API_PROTOCOL . '://' . Client::API_URL . '/_application';
+        return self::HOST . '://' . self::HOST . '/login/userinfo';
     }
 
     /**

--- a/src/Entity/AudioTalkBook.php
+++ b/src/Entity/AudioTalkBook.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Bookboon\Api\Entity;
+
+class AudioTalkBook extends Book
+{
+    const _OWN_TYPE = Book::TYPE_AUDIOTALK;
+}

--- a/src/Entity/Book.php
+++ b/src/Entity/Book.php
@@ -86,7 +86,13 @@ class Book extends Entity
     {
         $entities = array();
         foreach ($array as $object) {
-            $entities[] = self::objectTransformer($object);
+            if (in_array(
+                $object['_type'],
+                array(self::TYPE_PDF, self::TYPE_AUDIO, self::TYPE_VIDEO),
+                true)
+            ) {
+                $entities[] = self::objectTransformer($object);
+            }
         }
 
         return $entities;

--- a/src/Entity/Book.php
+++ b/src/Entity/Book.php
@@ -12,6 +12,7 @@ class Book extends Entity
     const TYPE_AUDIO = 'audio';
     const TYPE_PDF = 'pdf';
     const TYPE_VIDEO = 'video';
+    const TYPE_AUDIOTALK = 'audioTalk';
 
     const FORMAT_PDF = 'pdf';
     const FORMAT_EPUB = 'epub';
@@ -88,7 +89,7 @@ class Book extends Entity
         foreach ($array as $object) {
             if (in_array(
                 $object['_type'],
-                array(self::TYPE_PDF, self::TYPE_AUDIO, self::TYPE_VIDEO),
+                array(self::TYPE_PDF, self::TYPE_AUDIO, self::TYPE_VIDEO, self::TYPE_AUDIOTALK),
                 true)
             ) {
                 $entities[] = self::objectTransformer($object);

--- a/src/Entity/Book.php
+++ b/src/Entity/Book.php
@@ -123,11 +123,21 @@ class Book extends Entity
      * @param $query string to search for
      * @param int $limit results to return per page
      * @param int $offset offset of results
+     * @param string $bookType
      * @return Book[]
      */
-    public static function search(Bookboon $bookboon, $query, $limit = 10, $offset = 0)
+    public static function search(Bookboon $bookboon, $query, $limit = 10, $offset = 0, $bookType = self::TYPE_PDF)
     {
-        $search = $bookboon->rawRequest('/search', array('q' => $query, 'limit' => $limit, 'offset' => $offset));
+        $search = $bookboon->rawRequest(
+            '/search',
+            array(
+                'q' => $query,
+                'limit' => $limit,
+                'offset' => $offset,
+                'bookType' => $bookType
+            )
+        );
+
         if (count($search) === 0) {
             return array();
         }
@@ -144,9 +154,16 @@ class Book extends Entity
      * @param int $limit
      * @return Book[]
      */
-    public static function recommendations(Bookboon $bookboon, array $bookIds = array(), $limit = 5, $bookType = 'pdf')
+    public static function recommendations(Bookboon $bookboon, array $bookIds = array(), $limit = 5, $bookType = self::TYPE_PDF)
     {
-        $recommendations = $bookboon->rawRequest('/recommendations', array('limit' => $limit, 'book' => $bookIds, 'bookType' => $bookType));
+        $recommendations = $bookboon->rawRequest(
+            '/recommendations',
+            array(
+                'limit' => $limit,
+                'book' => $bookIds,
+                'bookType' => $bookType
+            )
+        );
 
         return Book::getEntitiesFromArray($recommendations);
     }

--- a/src/Entity/Category.php
+++ b/src/Entity/Category.php
@@ -16,11 +16,13 @@ class Category extends Entity
      *
      * @param Bookboon $bookboon
      * @param string $categoryId
-     * @return Category|bool
+     * @param string $bookType
+     * @return Category
+     * @throws \Bookboon\Api\Exception\EntityDataException
      */
-    public static function get(Bookboon $bookboon, $categoryId)
+    public static function get(Bookboon $bookboon, $categoryId, $bookType = Book::TYPE_PDF)
     {
-        return new static($bookboon->rawRequest("/categories/$categoryId"));
+        return new static($bookboon->rawRequest("/categories/$categoryId", array('bookType' => $bookType)));
     }
 
     /**

--- a/tests/Cache/HashTraitTest.php
+++ b/tests/Cache/HashTraitTest.php
@@ -40,6 +40,17 @@ class HashTraitTest extends \PHPUnit_Framework_TestCase
         $this->assertNotEquals($hash1, $hash2);
     }
 
+    /** @group tttt */
+    public function testHashLanguageHeader()
+    {
+        $mock = $this->getMockForTrait('\Bookboon\Api\Cache\HashTrait');
+
+        $hash1 = $mock->hash('/test', "WHATEVSID", array(Headers::HEADER_LANGUAGE => 'en, de', Headers::HEADER_BRANDING => 'branding-test'));
+        $hash2 = $mock->hash('/test', "WHATEVSID", array(Headers::HEADER_LANGUAGE => 'de, en', Headers::HEADER_BRANDING => 'branding-test'));
+
+        $this->assertNotEquals($hash1, $hash2);
+    }
+
     public function testRequestIsCacheable()
     {
         $mock = $this->getMockForTrait('\Bookboon\Api\Cache\HashTrait');


### PR DESCRIPTION
This MR should add audio talk to old platform, could be tag after `v2.4.3`.

To add expert talks to old platform of 2.* version book entity needs bookType `audioTalk` added 